### PR TITLE
Handle empty json and non-data labels better

### DIFF
--- a/adafruit_magtag/magtag.py
+++ b/adafruit_magtag/magtag.py
@@ -112,6 +112,7 @@ class MagTag:
         self._text_font = []
         self._text_line_spacing = []
         self._text_anchor_point = []
+        self._text_is_data = []
 
         gc.collect()
 
@@ -127,6 +128,7 @@ class MagTag:
         text_scale=1,
         line_spacing=1.25,
         text_anchor_point=(0, 0.5),
+        is_data=True,
     ):
         """
         Add text labels with settings
@@ -143,6 +145,10 @@ class MagTag:
                             length. Defaults to 0.
         :param text_transform: A function that will be called on the text before display
         :param int text_scale: The factor to scale the default size of the text by
+        :param float line_spacing: The factor to space the lines apart
+        :param (float, float) text_anchor_point: Values between 0 and 1 to indicate where the text
+                                                 position is relative to the label
+        :param bool is_data: If True, fetch will attempt to update the label
         """
         if text_font is terminalio.FONT:
             self._text_font.append(text_font)
@@ -174,6 +180,7 @@ class MagTag:
         self._text_scale.append(text_scale)
         self._text_line_spacing.append(line_spacing)
         self._text_anchor_point.append(text_anchor_point)
+        self._text_is_data.append(bool(is_data))
 
     # pylint: enable=too-many-arguments
 
@@ -358,17 +365,21 @@ class MagTag:
 
         # fill out all the text blocks
         if self._text:
+            value_index = 0  # In case values and text is not the same
             for i in range(len(self._text)):
+                if not self._text_is_data[i]:
+                    continue
                 string = None
                 if self._text_transform[i]:
                     func = self._text_transform[i]
-                    string = func(values[i])
+                    string = func(values[value_index])
                 else:
                     try:
-                        string = "{:,d}".format(int(values[i]))
+                        string = "{:,d}".format(int(values[value_index]))
                     except (TypeError, ValueError):
-                        string = values[i]  # ok its a string
+                        string = values[value_index]  # ok its a string
                 self.set_text(string, index=i, auto_refresh=False)
+                value_index += 1
         self.refresh()
         if len(values) == 1:
             return values[0]

--- a/adafruit_magtag/network.py
+++ b/adafruit_magtag/network.py
@@ -137,7 +137,12 @@ class Network:
                 "The json_path parameter should be enclosed in a list or tuple."
             )
         for x in path:
-            value = value[x]
+            try:
+                value = value[x]
+            except TypeError as error:
+                raise ValueError(
+                    "The specified json_path was not found in the results."
+                ) from error
             gc.collect()
         return value
 
@@ -512,7 +517,7 @@ class Network:
                 raise
 
         # extract desired text/values from json
-        if json_out and json_path:
+        if json_out is not None and json_path:
             for path in json_path:
                 try:
                     values.append(self.json_traverse(json_out, path))


### PR DESCRIPTION
Fixes #22.
Fixes #23.
When there's an unexpected json or your path does not match, this handles it much better. If you have some non-data labels, they can now be specified to not be data, otherwise they are treated as before so it shouldn't break any existing code.