### PR TITLE
Handle bad indices in the json_path

### DIFF
--- a/adafruit_magtag/network.py
+++ b/adafruit_magtag/network.py
@@ -139,7 +139,7 @@ class Network:
         for x in path:
             try:
                 value = value[x]
-            except (TypeError, KeyError) as error:
+            except (TypeError, KeyError, IndexError) as error:
                 raise ValueError(
                     "The specified json_path was not found in the results."
                 ) from error

--- a/adafruit_magtag/network.py
+++ b/adafruit_magtag/network.py
@@ -139,7 +139,7 @@ class Network:
         for x in path:
             try:
                 value = value[x]
-            except TypeError as error:
+            except (TypeError, KeyError) as error:
                 raise ValueError(
                     "The specified json_path was not found in the results."
                 ) from error


### PR DESCRIPTION
It currently handles bad names, but not indices. This fixes it.