### PR TITLE
return the index of the textbox created by add_text

### DIFF
--- a/adafruit_magtag/magtag.py
+++ b/adafruit_magtag/magtag.py
@@ -182,7 +182,7 @@ class MagTag:
         self._text_anchor_point.append(text_anchor_point)
         self._text_is_data.append(bool(is_data))
 
-        return len(self._text)-1
+        return len(self._text) - 1
 
     # pylint: enable=too-many-arguments
 

--- a/adafruit_magtag/magtag.py
+++ b/adafruit_magtag/magtag.py
@@ -182,6 +182,8 @@ class MagTag:
         self._text_anchor_point.append(text_anchor_point)
         self._text_is_data.append(bool(is_data))
 
+        return len(self._text)-1
+
     # pylint: enable=too-many-arguments
 
     @staticmethod


### PR DESCRIPTION
This allows developer to receive the index of the textbox which was just created.

Usage:

```
dateBox=magtag.add_text(blahblahblah)
timeBox=magtag.add_text(blahblahblah)
...various code...

magtag.set_text('the date',dateBox)
magtag.set_text('the time',timeBox)

```