### PR TITLE
Fix multiplier for battery voltage

### DIFF
--- a/adafruit_magtag/peripherals.py
+++ b/adafruit_magtag/peripherals.py
@@ -83,7 +83,7 @@ class Peripherals:
     @property
     def battery(self):
         """Return the voltage of the battery"""
-        return (self._batt_monitor.value / 65535.0) * 2.6 * 2
+        return (self._batt_monitor.value / 65535.0) * 3.3 * 2
 
     @property
     def neopixel_disable(self):


### PR DESCRIPTION
The battery voltage multiplier should be 3.3V, not 2.6V, because `AnalogIn` now compensates for the limited voltage range to some extent.

After this fix, the battery voltage is still low by about 0.15V, but I think that's a fix to be made in `AnalogIn`, and will work on that separately.