### PR TITLE
added PortalBase to Dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,7 @@ Dependencies
 This driver depends on:
 
 * `Adafruit CircuitPython <https://github.com/adafruit/circuitpython>`_
+* `Adafruit PortalBase <https://github.com/adafruit/Adafruit_CircuitPython_PortalBase>`_
 
 Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading


### PR DESCRIPTION
PortalBase wasn't listed in README.rst as a dependency