### PR TITLE
Don't let users play a tone equal or less than 0

### DIFF
--- a/adafruit_magtag/peripherals.py
+++ b/adafruit_magtag/peripherals.py
@@ -73,6 +73,8 @@ class Peripherals:
         It will attempt to play the sound up to 3 times in the case of
         an error.
         """
+        if frequency <= 0:
+            raise ValueError("The frequency has to be greater than 0.")
         self._speaker_enable.value = True
         attempt = 0
         # Try up to 3 times to play the sound


### PR DESCRIPTION
Previously, this would have caused a crash.