### PR TITLE
allow tone frequency of 0

### DIFF
--- a/adafruit_magtag/peripherals.py
+++ b/adafruit_magtag/peripherals.py
@@ -76,8 +76,8 @@ class Peripherals:
         It will attempt to play the sound up to 3 times in the case of
         an error.
         """
-        if frequency <= 0:
-            raise ValueError("The frequency has to be greater than 0.")
+        if frequency < 0:
+            raise ValueError("Negative frequencies are not allowed.")
         self._speaker_enable.value = True
         attempt = 0
         # Try up to 3 times to play the sound


### PR DESCRIPTION
I left an issue in the issues section, but decided I could simply make a pull request myself.  (I'm pretty new to the process).
This fix allows a specification of a zero frequency to the play_tone function.
Forum: [https://forums.adafruit.com/viewtopic.php?f=60&t=182821](forum)
Issue: [https://github.com/adafruit/Adafruit_CircuitPython_MagTag/issues/67](issue)
