### PR TITLE
initialize neopixel power pin before neopixels

### DIFF
--- a/adafruit_magtag/peripherals.py
+++ b/adafruit_magtag/peripherals.py
@@ -42,14 +42,15 @@ class Peripherals:
 
     # pylint: disable=too-many-instance-attributes, too-many-locals, too-many-branches, too-many-statements
     def __init__(self):
-        # Neopixels
-        self.neopixels = neopixel.NeoPixel(board.NEOPIXEL, 4, brightness=0.3)
+        # Neopixel power
         try:
             self._neopixel_disable = DigitalInOut(board.NEOPIXEL_POWER)
             self._neopixel_disable.direction = Direction.OUTPUT
             self._neopixel_disable.value = False
         except ValueError:
             self._neopixel_disable = None
+        # Neopixels
+        self.neopixels = neopixel.NeoPixel(board.NEOPIXEL, 4, brightness=0.3)
 
         # Battery Voltage
         self._batt_monitor = AnalogIn(board.BATTERY)


### PR DESCRIPTION
resolves: #75 

The neopixel library tries to initialize `NEOPIXEL_POWER` pin when you create the Neopixel object. It gracefully handles "pin in use" error.  So we can initialize `NEOPIXEL_POWER` inside of MagTag library before creating the Neopixel object, that way the MagTag library will happen first and keep control of the power pin.

Tested successfully with reproducer code from the issue on MagTag 7.1.0 beta