### PR TITLE
Correct use of board.NEOPIXEL as status_neopixel parameter

### DIFF
--- a/adafruit_magtag/magtag.py
+++ b/adafruit_magtag/magtag.py
@@ -29,6 +29,7 @@ Implementation Notes
 
 import gc
 import time
+import board
 from adafruit_portalbase import PortalBase
 from adafruit_magtag.network import Network
 from adafruit_magtag.graphics import Graphics
@@ -75,6 +76,11 @@ class MagTag(PortalBase):
         debug=False,
     ):
 
+        self.peripherals = Peripherals()
+
+        if status_neopixel == board.NEOPIXEL:
+            status_neopixel = self.peripherals.neopixels
+
         network = Network(
             status_neopixel=status_neopixel,
             extract_values=False,
@@ -98,8 +104,6 @@ class MagTag(PortalBase):
             json_transform=json_transform,
             debug=debug,
         )
-
-        self.peripherals = Peripherals()
 
         gc.collect()
 

--- a/adafruit_magtag/network.py
+++ b/adafruit_magtag/network.py
@@ -55,7 +55,10 @@ class Network(NetworkBase):
         debug=False,
     ):
         if status_neopixel:
-            status_led = neopixel.NeoPixel(status_neopixel, 1, brightness=0.2)
+            if isinstance(status_neopixel, neopixel.NeoPixel):
+                status_led = status_neopixel
+            else:
+                status_led = neopixel.NeoPixel(status_neopixel, 1, brightness=0.2)
         else:
             status_led = None
         super().__init__(


### PR DESCRIPTION
Move init of Peripherals() to be done before init of Network() so that board's neopixels are done first, then passed to Network() if status_neopixel uses board.NEOPIXEL. If any other pin is used, it will be passed as is.