### PR TITLE
Adds `BOOT0` as a fifth pin for the `Peripherals.buttons` list.

### DIFF
--- a/adafruit_magtag/peripherals.py
+++ b/adafruit_magtag/peripherals.py
@@ -65,7 +65,13 @@ class Peripherals:
 
         # Buttons
         self.buttons = []
-        for pin in (board.BUTTON_A, board.BUTTON_B, board.BUTTON_C, board.BUTTON_D, board.BOOT0):
+        for pin in (
+            board.BUTTON_A,
+            board.BUTTON_B,
+            board.BUTTON_C,
+            board.BUTTON_D,
+            board.BOOT0,
+        ):
             switch = DigitalInOut(pin)
             switch.direction = Direction.INPUT
             switch.pull = Pull.UP

--- a/adafruit_magtag/peripherals.py
+++ b/adafruit_magtag/peripherals.py
@@ -64,14 +64,14 @@ class Peripherals:
         self._light = AnalogIn(board.LIGHT)
 
         # Buttons
+        button_pins = [board.BUTTON_A, board.BUTTON_B, board.BUTTON_C, board.BUTTON_D]
+
+        # Add BOOT0 as a button pin, only if it's defined.
+        if hasattr(board, "BOOT0"):
+            button_pins.append(board.BOOT0)
+
         self.buttons = []
-        for pin in (
-            board.BUTTON_A,
-            board.BUTTON_B,
-            board.BUTTON_C,
-            board.BUTTON_D,
-            board.BOOT0,
-        ):
+        for pin in button_pins:
             switch = DigitalInOut(pin)
             switch.direction = Direction.INPUT
             switch.pull = Pull.UP

--- a/adafruit_magtag/peripherals.py
+++ b/adafruit_magtag/peripherals.py
@@ -65,7 +65,7 @@ class Peripherals:
 
         # Buttons
         self.buttons = []
-        for pin in (board.BUTTON_A, board.BUTTON_B, board.BUTTON_C, board.BUTTON_D):
+        for pin in (board.BUTTON_A, board.BUTTON_B, board.BUTTON_C, board.BUTTON_D, board.BOOT0):
             switch = DigitalInOut(pin)
             switch.direction = Direction.INPUT
             switch.pull = Pull.UP


### PR DESCRIPTION
Added the `BOOT0` button as a fifth pin for the buttons list.

This is dependant on https://github.com/adafruit/circuitpython/pull/6657, where I added the pin's name to the board's port. I'm not sure if the BOOT0 pin was skipped intentionally or not, so I'm opening this as a draft until that PR gets looked at.