### PR TITLE
Update magtag_quote_demo.py

### DIFF
--- a/examples/magtag_quote_demo.py
+++ b/examples/magtag_quote_demo.py
@@ -19,7 +19,6 @@ except AttributeError:
 magtag = MagTag(
     url=DATA_SOURCE,
     json_path=(QUOTE_LOCATION, AUTHOR_LOCATION),
-    default_bg=0x000000,
 )
 
 
@@ -36,7 +35,6 @@ magtag.add_text(
         (magtag.graphics.display.width // 2) - 1,
         (magtag.graphics.display.height // 2) - 20,
     ),
-    text_color=0xFFFFFF,
     text_wrap=44,
     text_maxlen=180,
     line_spacing=1.0,
@@ -49,7 +47,6 @@ magtag.add_text(
         (magtag.graphics.display.width // 2) - 120,
         (magtag.graphics.display.height // 2) + 34,
     ),
-    text_color=0xFFFFFF,
     text_wrap=0,
     text_maxlen=30,
     text_transform=add_hyphen,


### PR DESCRIPTION
testing with magtag 2025 and the colors are coming up inverted if set directly (bg is black and text is white). if i set the background to `0xFFFFFF` and text to `0x000000` then the background was white and the text was black. the other examples leave text_color and default_bg as default and show correctly so that's what i've done here.

not sure if this is an issue though with the new display and how it is init in the core or in portalbase/this library because setting the color i imagine should work