### PR TITLE
Wait for display on deep sleep

### DIFF
--- a/adafruit_magtag/magtag.py
+++ b/adafruit_magtag/magtag.py
@@ -36,6 +36,7 @@ from adafruit_portalbase import PortalBase
 from adafruit_magtag.graphics import Graphics
 from adafruit_magtag.network import Network
 from adafruit_magtag.peripherals import Peripherals
+from supervisor import reload
 
 try:
     from typing import Any, Callable, Dict, Optional, Sequence, Union
@@ -130,10 +131,17 @@ class MagTag(PortalBase):
         :param float sleep_time: The amount of time to sleep in seconds
 
         """
+        while board.DISPLAY.busy:
+            self.enter_light_sleep(1)
+            sleep_time -= 1
+
         if self._alarm:
             self.peripherals.neopixel_disable = True
             self.peripherals.speaker_disable = True
-        super().exit_and_deep_sleep(sleep_time)
+        try:
+            super().exit_and_deep_sleep(sleep_time)
+        except ValueError:
+            reload()
 
     def enter_light_sleep(self, sleep_time: float) -> None:
         """

--- a/adafruit_magtag/magtag.py
+++ b/adafruit_magtag/magtag.py
@@ -28,7 +28,7 @@ Implementation Notes
 """
 
 import gc
-import time
+from time import sleep
 
 import board
 from adafruit_portalbase import PortalBase
@@ -36,7 +36,6 @@ from adafruit_portalbase import PortalBase
 from adafruit_magtag.graphics import Graphics
 from adafruit_magtag.network import Network
 from adafruit_magtag.peripherals import Peripherals
-from supervisor import reload
 
 try:
     from typing import Any, Callable, Dict, Optional, Sequence, Union
@@ -131,17 +130,10 @@ class MagTag(PortalBase):
         :param float sleep_time: The amount of time to sleep in seconds
 
         """
-        while board.DISPLAY.busy:
-            self.enter_light_sleep(1)
-            sleep_time -= 1
-
         if self._alarm:
             self.peripherals.neopixel_disable = True
             self.peripherals.speaker_disable = True
-        try:
-            super().exit_and_deep_sleep(sleep_time)
-        except ValueError:
-            reload()
+        super().exit_and_deep_sleep(sleep_time)
 
     def enter_light_sleep(self, sleep_time: float) -> None:
         """
@@ -202,16 +194,22 @@ class MagTag(PortalBase):
             self.refresh()
         return values
 
-    def refresh(self) -> None:
+    def refresh(self, blocking=True) -> None:
         """
         Refresh the display
+
+        :param blocking: Wait to return until the display refresh is complete.
+                         Defaults to True
+
         """
         while True:
             try:
                 self.graphics.display.refresh()
+                while blocking and board.DISPLAY.busy:
+                    sleep(1)
                 return
             except RuntimeError:
-                time.sleep(1)
+                sleep(1)
 
     def remove_all_text(self, auto_refresh=True, clear_font_cache=False):
         """Remove all added text and labels.


### PR DESCRIPTION
With a MagTag 2025 Edition, `MagTag.exit_and_deep_sleep()` can fail to restart the board if it is called while the display is still updating. I documented this in [issue 10639 for CircuitPython](https://github.com/adafruit/circuitpython/issues/10639).

As a workaround, I added a while loop to test `board.DISPLAY.busy`, which enters light sleep while waiting for the display to finish updating. I also added a try/except block around the call to `super().exit_and_deep_sleep()` since the updated sleep_time value could be negative. Finally, in the exception handling, I call `supervisor.reload()` instead of `microcontroller.reset()` because the latter flashes the neopixels, unlike the original behavior of `MagTag.exit_and_deep_sleep()`.
