### PR TITLE
Add button_e_pressed property and make any_button_pressed dynamic

### DIFF
--- a/adafruit_magtag/peripherals.py
+++ b/adafruit_magtag/peripherals.py
@@ -166,7 +166,7 @@ class Peripherals:
         Return whether Button D is pressed
         """
         return not self.buttons[3].value
-    
+
     @property
     def button_e_pressed(self) -> bool:
         """

--- a/adafruit_magtag/peripherals.py
+++ b/adafruit_magtag/peripherals.py
@@ -166,13 +166,20 @@ class Peripherals:
         Return whether Button D is pressed
         """
         return not self.buttons[3].value
+    
+    @property
+    def button_e_pressed(self) -> bool:
+        """
+        Return whether Button E is pressed
+        """
+        return not self.buttons[4].value
 
     @property
     def any_button_pressed(self) -> bool:
         """
         Return whether any button is pressed
         """
-        return False in [self.buttons[i].value for i in range(0, 4)]
+        return False in [button.value for button in self.buttons]
 
     @property
     def light(self) -> int:


### PR DESCRIPTION
Fixes #98

### Description of Changes
- Added the missing `button_e_pressed` property for the `BOOT0` button.
- Refactored `any_button_pressed` to dynamically iterate through the `self.buttons` list using a list comprehension instead of using a hardcoded range. This prevents future bugs if more buttons are added to the hardware.

### Testing Done
- Verified the core logic locally by running a custom python unit test script using `unittest.mock.MagicMock` to simulate the hardware peripheral states. All logic passed successfully.